### PR TITLE
Fix #7: Add generic manager functionality, support lastpass

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,22 @@
 
 [![Build Status](https://travis-ci.org/yardnsm/tmux-1password.svg?branch=master)](https://travis-ci.org/yardnsm/tmux-1password)
 
-> Access your 1Password login items within tmux!
+> Access your 1Password and lastpass login items within tmux!
 
 ![](.github/screenshot.gif)
 
-This plugin allows you to access you 1Password items within tmux, using 1Password's CLI. It works
-for personal 1Password accounts, as well as teams accounts.
+This plugin allows you to access you password items within tmux, using a password manager's CLI.
+
+Supported managers:
+
+* Personal 1Password accounts, as well as teams accounts
+* lastpass-cli
 
 ## Requirements
 
 This plugin relies on the following:
 
-- [1Password CLI](https://support.1password.com/command-line-getting-started/)
+- [1Password CLI](https://support.1password.com/command-line-getting-started/) (or other cli)
 - [fzf](https://github.com/junegunn/fzf)
 - [jq](https://stedolan.github.io/jq/)
 
@@ -57,8 +61,8 @@ In any tmux mode:
 
 ## Usage
 
-First, sign in with 1Password CLI by running the following in your terminal (you only need to do
-this *once*):
+First, sign in with the CLI by running the following in your terminal (you only need to do
+this *once*)(1Password example provided):
 
 ```console
 $ op signin <signinaddress> <emailaddress> <secretkey>
@@ -85,6 +89,20 @@ In order to show only relevant login items and to maintain compatibility with
 Customize this plugin by setting these options in your `.tmux.conf` file. Make sure to reload the
 environment afterwards.
 
+#### Set Lastpass username (required when logging in again)
+
+```
+set -g @lastpass-username 'x'
+```
+
+#### Changing the default manager for this plugin
+
+This should be the command typed at the prompt.
+
+```
+set -g @password-manager-cmd 'op'
+```
+
 #### Changing the default key-binding for this plugin
 
 ```
@@ -93,7 +111,7 @@ set -g @1password-key 'x'
 
 Default: `'u'`
 
-#### Setting the signin subdomain
+#### Setting the 1Password signin subdomain
 
 ```
 set -g @1password-subdomain 'acme'
@@ -101,7 +119,7 @@ set -g @1password-subdomain 'acme'
 
 Default: `'my'`
 
-#### Setting the default vault
+#### Setting the default 1Password vault
 
 ```
 set -g @1password-vault 'work'
@@ -128,6 +146,10 @@ Also see:
 - [sudolikeaboss](https://github.com/ravenac95/sudolikeaboss)
 
 ---
+
+## Adding new managers
+
+Read password_manager_configs.d/configuring_managers.md
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/yardnsm/tmux-1password.svg?branch=master)](https://travis-ci.org/yardnsm/tmux-1password)
 
-> Access your 1Password and lastpass login items within tmux!
+> Access your password manager login items within tmux!
 
 ![](.github/screenshot.gif)
 
@@ -12,6 +12,12 @@ Supported managers:
 
 * Personal 1Password accounts, as well as teams accounts
 * lastpass-cli
+
+In the works:
+
+* 1pass (`on` wrapper)
+
+Additional managers should be easy to integrate, especially if they can output `json` format.
 
 ## Requirements
 
@@ -78,11 +84,13 @@ and its password will automatically be filled.
 You may be required to perform a re-login (directly in the opened pane) since the 1Password CLI's
 sessions expires automatically after 30 minutes of inactivity.
 
-### Configuring login items in 1Password
+If your manager logs you out (or some other error means no login items can be found) you will be asked to log in again.
+
+### Showing login items from manager
 
 In order to show only relevant login items and to maintain compatibility with
 [sudolikeaboss](https://github.com/ravenac95/sudolikeaboss), its required to set the value of the
-`website` field for each login item with the value of `sudolikeaboss://local`.
+`website` or `url` field for each login item with the value of `sudolikeaboss://local`.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,11 @@ Default: `''` (all vaults)
 
 By default, the plugin will use `send-keys` to send the selected password to the targeted pane. By
 setting the following, the password will be copied to the system's clipboard, which will be cleared
-after 30 seconds.
+after `1password-clipboard-duration` seconds (default 30).
 
 ```
 set -g @1password-copy-to-clipboard 'on'
+set -g @1password-clipboard-duration '30'
 ```
 
 Default: `'off'`

--- a/password_manager_configs.d/1pass.sh
+++ b/password_manager_configs.d/1pass.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# vim:ts=2:sw=2
+logincmd="1pass"
+otherOptsLogin=""
+listcmd="1pass"
+otherOptsList=""
+getcmd="-p"
+otherOptsGet=""
+
+
+USE_CUSTOM_FILTERS=true
+
+JQ_FILTER_LIST="
+.[]
+| [select(.url == \"$FILTER_URL\")]
+| map([ .name, .name ]
+| join(\",\"))
+| .[]
+"
+JQ_FILTER_GET=".[].password"
+JQ_FILTER_LIST="
+.[]
+| [select(.overview.URLs | map(select(.u == \"sudolikeaboss://local\")) | length == 1)?]
+| map([ .overview.title, .uuid ]
+| join(\",\"))
+| .[]
+"
+JQ_FILTER_GET="
+.details
+| if .password then
+.password
+  else
+    .fields[]
+    | select (.designation == \"password\")
+    | .value
+  end
+"
+
+convertToJson(){
+  input="$*"
+  output=""
+  json="[{}]"
+  # for line in $input; do
+  #   json=$(jq "add_element")
+  # done
+}
+
+# 1pass can only do 2 things: list names, and return a password. Tricky to convert to json...
+filter_list_custom(){
+  local -r input="$*"
+  convertToJson "$input"
+  echo $input | jq "$JQ_FILTER_LIST" --raw-output
+}
+
+filter_get_custom(){
+  local -r input="$*"
+  echo $input | jq "$JQ_FILTER_GET" --raw-output
+}

--- a/password_manager_configs.d/1pass.sh
+++ b/password_manager_configs.d/1pass.sh
@@ -45,14 +45,16 @@ convertToJson(){
   # done
 }
 
-# 1pass can only do 2 things: list names, and return a password. Tricky to convert to json...
+# 1pass can only do 2 things: list names, and return a password. No json.
 filter_list_custom(){
   local -r input="$*"
-  convertToJson "$input"
-  echo $input | jq "$JQ_FILTER_LIST" --raw-output
+  while read -r line; do
+    output="${output}${line},${line}\n"
+  done <<< "$input"
+  echo $output
 }
 
 filter_get_custom(){
   local -r input="$*"
-  echo $input | jq "$JQ_FILTER_GET" --raw-output
+  echo 1pass -p $input
 }

--- a/password_manager_configs.d/configuring_managers.md
+++ b/password_manager_configs.d/configuring_managers.md
@@ -1,11 +1,18 @@
-Files in this directory needs to declare variables `logincmd`, `listcmd`, and `getcmd`.
+Files in this directory need to be named `[password manager cli command].sh` and should declare several variables:
 
-They also need to declare two functions:
+* `logincmd`
+* `listcmd`
+* `getcmd`
+* `JQ_FILTER_LIST`
+* `JQ_FILTER_GET`
 
-* `filter_list` that takes as a parameter the output of `listcmd`,
+`listcmd` and `getcmd` should return a .json.
+
+* `JQ_FILTER_LIST` is a string containing a JQ_FILTER that takes the output of `listcmd`,
 and returns "`name`,`uuid`", where:
 
     - `name` = a human-readable identifier
     - `uuid` = a unique identifier.
 
-* `filter_get` that takes the output of `getcmd` and returns the password only.
+* `JQ_FILTER_GET` that takes the output of `getcmd` and returns the password only.
+

--- a/password_manager_configs.d/configuring_managers.md
+++ b/password_manager_configs.d/configuring_managers.md
@@ -1,5 +1,11 @@
 Files in this directory needs to declare variables `logincmd`, `listcmd`, and `getcmd`.
 
-They also need to declare a function called `filter_list` that takes the output
-of `listcmd` and returns only the records you need, and a function called
-`filter_get` that takes the output of `getcmd` and returns the password only.
+They also need to declare two functions:
+
+* `filter_list` that takes as a parameter the output of `listcmd`,
+and returns "`name`,`uuid`", where:
+
+    - `name` = a human-readable identifier
+    - `uuid` = a unique identifier.
+
+* `filter_get` that takes the output of `getcmd` and returns the password only.

--- a/password_manager_configs.d/configuring_managers.md
+++ b/password_manager_configs.d/configuring_managers.md
@@ -1,0 +1,5 @@
+Files in this directory needs to declare variables `logincmd`, `listcmd`, and `getcmd`.
+
+They also need to declare a function called `filter_list` that takes the output
+of `listcmd` and returns only the records you need, and a function called
+`filter_get` that takes the output of `getcmd` and returns the password only.

--- a/password_manager_configs.d/configuring_managers.md
+++ b/password_manager_configs.d/configuring_managers.md
@@ -16,3 +16,6 @@ and returns "`name`,`uuid`", where:
 
 * `JQ_FILTER_GET` that takes the output of `getcmd` and returns the password only.
 
+Alternatively, if more custom filtering is required (eg to create a json output
+if the manager doesn't support it natively), set `USE_CUSTOM_FILTER`
+and declare your own `filter_list_custom` function here.

--- a/password_manager_configs.d/configuring_managers.md
+++ b/password_manager_configs.d/configuring_managers.md
@@ -17,5 +17,5 @@ and returns "`name`,`uuid`", where:
 * `JQ_FILTER_GET` that takes the output of `getcmd` and returns the password only.
 
 Alternatively, if more custom filtering is required (eg to create a json output
-if the manager doesn't support it natively), set `USE_CUSTOM_FILTER`
-and declare your own `filter_list_custom` function here.
+if the manager doesn't support it natively), set `USE_CUSTOM_FILTERS`
+and declare your own `filter_list_custom` `filter_get_custom` functions here.

--- a/password_manager_configs.d/lpass.sh
+++ b/password_manager_configs.d/lpass.sh
@@ -3,6 +3,7 @@
 logincmd="login"
 if [ "$OPT_LPASS_USER" == "unset" ]; then
   echo "set @lastpass_username in tmux options"
+  sleep 5
   exit
 fi
 otherOptsLogin="$OPT_LPASS_USER"
@@ -14,21 +15,11 @@ otherOptsList=".*"
 getcmd="show"
 otherOptsGet="--json"
 
-filter_list(){
-  local -r input="$*"
-  local -r FILTER_URL="sudolikeaboss://local"
-  local -r JQ_FILTER="
-  .[]
-  | [select(.url == \"$FILTER_URL\")]
-  | map([ .name, .id ]
-  | join(\",\"))
-  | .[]
-  "
-  echo $input | jq "$JQ_FILTER" --raw-output
-}
-
-filter_get(){
-  local -r input="$*"
-  local -r JQ_FILTER=".[].password"
-  echo $input | jq "$JQ_FILTER" --raw-output
-}
+JQ_FILTER_LIST="
+.[]
+| [select(.url == \"$FILTER_URL\")]
+| map([ .name, .id ]
+| join(\",\"))
+| .[]
+"
+JQ_FILTER_GET=".[].password"

--- a/password_manager_configs.d/lpass.sh
+++ b/password_manager_configs.d/lpass.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# vim:ts=2:sw=2
+logincmd="login"
+if [ "$OPT_LPASS_USER" == "unset" ]; then
+  echo "set @lastpass_username in tmux options"
+  exit
+fi
+otherOptsLogin="$OPT_LPASS_USER"
+# listcmd="ls"
+# Creates an output that will match 1pass's output
+# 1pass_format_str=" [{ \"uuid\": \"%ai\", \"overview\": { \"URLs\": [ {\"u\": \"%al\" } ], \"title\": \"%an\" } }] "
+listcmd="show --json --expand-multi -G"
+otherOptsList=".*"
+getcmd="show"
+otherOptsGet="--json"
+
+filter_list(){
+  local -r input="$*"
+  local -r FILTER_URL="sudolikeaboss://local"
+  local -r JQ_FILTER="
+  .[]
+  | [select(.url == \"$FILTER_URL\")]
+  | map([ .name, .id ]
+  | join(\",\"))
+  | .[]
+  "
+  echo $input | jq "$JQ_FILTER" --raw-output
+}
+
+filter_get(){
+  local -r input="$*"
+  local -r JQ_FILTER=".[].password"
+  echo $input | jq "$JQ_FILTER" --raw-output
+}

--- a/password_manager_configs.d/on.sh
+++ b/password_manager_configs.d/on.sh
@@ -8,6 +8,7 @@ getcmd="get item"
 otherOptsGet="--session=\"$(get_session)\""
 
 filter_list(){
+  input="$*"
   # The structure to be filtered from `on show items` is this:
   # [
   #   {
@@ -20,7 +21,6 @@ filter_list(){
   #     }
   #   }
   # ]
-  read input
   local -r JQ_FILTER="
   .[]
   | [select(.overview.URLs | map(select(.u == \"sudolikeaboss://local\")) | length == 1)?]
@@ -32,6 +32,7 @@ filter_list(){
 }
 
 filter_get(){
+  input="$*"
   # There are two different kind of items that
   # we support: login items and passwords.
   #
@@ -53,7 +54,6 @@ filter_get(){
   #           "password": "supersecret"
   #         }
   #       }
-  read input
   local -r JQ_FILTER="
     .details
     | if .password then
@@ -64,5 +64,5 @@ filter_get(){
     | .value
   end
 "
-echo $input | jq "$JQ_FILTER" --raw-output
+  echo $input | jq "$JQ_FILTER" --raw-output
 }

--- a/password_manager_configs.d/on.sh
+++ b/password_manager_configs.d/on.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# vim:ts=2:sw=2
+logincmd="signin"
+otherOptsLogin="\"$OPT_SUBDOMAIN\" --output=raw"
+listcmd="list items"
+otherOptsList="--vault=\"$OPT_VAULT\" --session=\"$(get_session)\""
+getcmd="get item"
+otherOptsGet="--session=\"$(get_session)\""
+
+filter_list(){
+  # The structure to be filtered from `on show items` is this:
+  # [
+  #   {
+  #     "uuid": "some-long-uuid",
+  #     "overview": {
+  #       "URLs": [
+  #         { "u": "sudolikeaboss://local" }
+  #       ],
+  #       "title": "Some item"
+  #     }
+  #   }
+  # ]
+  read input
+  local -r JQ_FILTER="
+  .[]
+  | [select(.overview.URLs | map(select(.u == \"sudolikeaboss://local\")) | length == 1)?]
+  | map([ .overview.title, .uuid ]
+  | join(\",\"))
+  | .[]
+  "
+  echo $input | jq "$JQ_FILTER" --raw-output
+}
+
+filter_get(){
+  # There are two different kind of items that
+  # we support: login items and passwords.
+  #
+  # * Login items:
+  #       {
+  #         "details": {
+  #           "fields": [
+  #             {
+  #               "designation": "password",
+  #               "value": "supersecret"
+  #             }
+  #           ]
+  #         }
+  #       }
+  #
+  # * Password:
+  #       {
+  #         "details": {
+  #           "password": "supersecret"
+  #         }
+  #       }
+  read input
+  local -r JQ_FILTER="
+    .details
+    | if .password then
+    .password
+  else
+    .fields[]
+    | select (.designation == \"password\")
+    | .value
+  end
+"
+echo $input | jq "$JQ_FILTER" --raw-output
+}

--- a/plugin.tmux
+++ b/plugin.tmux
@@ -12,7 +12,6 @@ source "./scripts/utils.sh"
 declare -r CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 declare -a REQUIRED_COMMANDS=(
-  'op'
   'jq'
   'fzf'
 )

--- a/scripts/filtertest.sh
+++ b/scripts/filtertest.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-filter="'.[] | [select(.overview.URLs | map(select(.u == \"wiggle.co.nz\")) | length == 1)?] | map([ .overview.title, .uuid ] | join(\",\")) | .[] '"
-lpass show --json --expand-multi -G '.*' | jq $filter

--- a/scripts/filtertest.sh
+++ b/scripts/filtertest.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+filter="'.[] | [select(.overview.URLs | map(select(.u == \"wiggle.co.nz\")) | length == 1)?] | map([ .overview.title, .uuid ] | join(\",\")) | .[] '"
+lpass show --json --expand-multi -G '.*' | jq $filter

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -81,7 +81,7 @@ get_items() {
 }
 
 filter_list(){
-  if [ -n "$USE_CUSTOM_FILTER" ]; then
+  if [ -n "$USE_CUSTOM_FILTERS" ]; then
     filter_list_custom "$@"
   else
     local -r input="$*"
@@ -99,8 +99,12 @@ get_item_password() {
 }
 
 filter_get(){
-  local -r input="$*"
-  echo $input | jq "$JQ_FILTER_GET" --raw-output
+  if [ -n "$USE_CUSTOM_FILTERS" ]; then
+    filter_get_custom "$@"
+  else
+    local -r input="$*"
+    echo $input | jq "$JQ_FILTER_GET" --raw-output
+  fi
 }
 
 # ------------------------------------------------------------------------------

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -70,14 +70,14 @@ get_session() {
 }
 
 get_items() {
-  # manager list --vault="$OPT_VAULT" --session="$(get_session)" 2> /dev/null \
-  manager list filter_list
+    filter_list "$(manager list 2> /dev/null)"
+    # filter_list "$(manager list)"
 }
 
 get_item_password() {
   local -r ITEM_UUID="$1"
-  # manager list --vault="$OPT_VAULT" --session="$(get_session)" 2> /dev/null \
-  manager get "$ITEM_UUID" filter_get
+  filter_get "$(manager get $ITEM_UUID 2> /dev/null)"
+  # filter_get "$(manager get $ITEM_UUID)"
 }
 
 # ------------------------------------------------------------------------------

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -74,7 +74,7 @@ get_session() {
 
 get_items() {
   if [ "$OPT_DEBUG" == "true" ]; then
-    filter_list "$(manager list)"
+    filter_list "$(manager list)" > /dev/stderr
   else
     filter_list "$(manager list 2> /dev/null)"
   fi
@@ -92,7 +92,7 @@ filter_list(){
 get_item_password() {
   local -r ITEM_UUID="$1"
   if [ "$OPT_DEBUG" == "true" ]; then
-    filter_get "$(manager get $ITEM_UUID)"
+    filter_get "$(manager get $ITEM_UUID)" > /dev/stderr
   else
     filter_get "$(manager get $ITEM_UUID 2> /dev/null)"
   fi
@@ -123,11 +123,17 @@ main() {
 
   if [[ -z "$items" ]]; then
 
+    if [ "$OPT_DEBUG" == "true" ]; then
+      # Give time to read any messages
+      sleep, 10
+    fi
     # Needs to login
     login
 
     if [[ -z "$(get_session)" ]]; then
       display_message "1Password CLI signin has failed"
+      # Give time to read any messages
+      sleep, 10
       return 0
     fi
 

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -81,8 +81,12 @@ get_items() {
 }
 
 filter_list(){
-  local -r input="$*"
-  echo $input | jq "$JQ_FILTER_LIST" --raw-output
+  if [ -n "$USE_CUSTOM_FILTER" ]; then
+    filter_list_custom "$@"
+  else
+    local -r input="$*"
+    echo $input | jq "$JQ_FILTER_LIST" --raw-output
+  fi
 }
 
 get_item_password() {

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -21,6 +21,8 @@ declare -r OPT_DEBUG="$(get_tmux_option "@tmux-1pass-debug" "false")"
 
 declare spinner_pid=""
 
+FILTER_URL="sudolikeaboss://local"
+
 source ../password_manager_configs.d/$OPT_MANAGER.sh
 
 # ------------------------------------------------------------------------------
@@ -78,6 +80,11 @@ get_items() {
   fi
 }
 
+filter_list(){
+  local -r input="$*"
+  echo $input | jq "$JQ_FILTER_LIST" --raw-output
+}
+
 get_item_password() {
   local -r ITEM_UUID="$1"
   if [ "$OPT_DEBUG" == "true" ]; then
@@ -85,6 +92,11 @@ get_item_password() {
   else
     filter_get "$(manager get $ITEM_UUID 2> /dev/null)"
   fi
+}
+
+filter_get(){
+  local -r input="$*"
+  echo $input | jq "$JQ_FILTER_GET" --raw-output
 }
 
 # ------------------------------------------------------------------------------
@@ -105,7 +117,6 @@ main() {
 
     # Needs to login
     login
-    echo logged in
 
     if [[ -z "$(get_session)" ]]; then
       display_message "1Password CLI signin has failed"

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -17,6 +17,7 @@ declare -r OPT_SUBDOMAIN="$(get_tmux_option "@1password-subdomain" "my")"
 declare -r OPT_VAULT="$(get_tmux_option "@1password-vault" "")"
 declare -r OPT_COPY_TO_CLIPBOARD="$(get_tmux_option "@1password-copy-to-clipboard" "off")"
 declare -r OPT_MANAGER="$(get_tmux_option "@password-manager-cmd" "on")"
+declare -r OPT_DEBUG="$(get_tmux_option "@tmux-1pass-debug" "false")"
 
 declare spinner_pid=""
 
@@ -70,14 +71,20 @@ get_session() {
 }
 
 get_items() {
+  if [ "$OPT_DEBUG" == "true" ]; then
+    filter_list "$(manager list)"
+  else
     filter_list "$(manager list 2> /dev/null)"
-    # filter_list "$(manager list)"
+  fi
 }
 
 get_item_password() {
   local -r ITEM_UUID="$1"
-  filter_get "$(manager get $ITEM_UUID 2> /dev/null)"
-  # filter_get "$(manager get $ITEM_UUID)"
+  if [ "$OPT_DEBUG" == "true" ]; then
+    filter_get "$(manager get $ITEM_UUID)"
+  else
+    filter_get "$(manager get $ITEM_UUID 2> /dev/null)"
+  fi
 }
 
 # ------------------------------------------------------------------------------

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -16,6 +16,7 @@ declare -r OPT_LPASS_USER="$(get_tmux_option "@lastpass-username" "unset")"
 declare -r OPT_SUBDOMAIN="$(get_tmux_option "@1password-subdomain" "my")"
 declare -r OPT_VAULT="$(get_tmux_option "@1password-vault" "")"
 declare -r OPT_COPY_TO_CLIPBOARD="$(get_tmux_option "@1password-copy-to-clipboard" "off")"
+declare -r OPT_CLEAR_CLIPBOARD_TIME="$(get_tmux_option "@1password-clipboard-duration" "30")"
 declare -r OPT_MANAGER="$(get_tmux_option "@password-manager-cmd" "on")"
 declare -r OPT_DEBUG="$(get_tmux_option "@tmux-1pass-debug" "false")"
 
@@ -157,7 +158,7 @@ main() {
       copy_to_clipboard "$selected_item_password"
 
       # Clear clipboard
-      clear_clipboard 30
+      clear_clipboard ${OPT_CLEAR_CLIPBOARD_TIME}
     else
 
       # Use `send-keys`


### PR DESCRIPTION
Apologies, but making this generic required a large re-write so it's not a small PR.

This takes the password manager specific commands and replaces them with a generic version, that calls the specific version based on variables. These variables are set in separate files, kinda like plugins.

This PR in particular has only been tested to work with lastpass, not 1password, so needs serious testing. I don't think I've changed any of the specifics though, just moved them, and the same generic code works for the lastpass specifics, so I'm hopeful it still works.

I've updated the readme and added configuration documentation.

There's also the shell of a 1pass version for #6, but again, it's entirely untested and required some extra new custom code.