### PR TITLE
get_op_item_password uses .password only when not null and not empty

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -97,7 +97,7 @@ get_op_item_password() {
 
   local -r JQ_FILTER="
     .details
-    | if .password then
+    | if .password and .password != \"\" then
         .password
       else
         .fields[]


### PR DESCRIPTION
Address issue #10 