### PR TITLE
Feature: Local cache for op items

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ sessions expires automatically after 30 minutes of inactivity.
 ### Configuring login items in 1Password
 
 In order to show only relevant login items and to maintain compatibility with
-[sudolikeaboss](https://github.com/ravenac95/sudolikeaboss), its required to set the value of the
-`website` field for each login item with the value of `sudolikeaboss://local`.
+[sudolikeaboss](https://github.com/ravenac95/sudolikeaboss), by default it is required to set the value of the
+`website` field for each login item with the value of `sudolikeaboss://local`. To override this behavior and provide
+customized filtering, see configuration options `@1password-enabled-url-filter` and `@1password-items-jq-filter` below.
 
 ## Configuration
 
@@ -120,6 +121,54 @@ set -g @1password-copy-to-clipboard 'on'
 ```
 
 Default: `'off'`
+
+#### Enabled URL Filter
+
+By default, the plugin maintains compatibility with [sudolikeaboss](https://github.com/ravenac95/sudolikeaboss) by
+filtering urls using the string "sudolikeaboss://local", by setting the following, the list of items will no longer be
+filtered.
+
+```
+set -g @1password-enabled-url-filter 'off'
+```
+
+Default: `'on'`
+
+#### Customize URL Filtering
+
+If complete customization of url filtering is required, a `jq` filter can be provided to filter and map
+items.
+
+##### Filtering by tags
+
+```
+set -g @1password-items-jq-filter '.[] | [select(.overview.tags | map(select(. == "tag_name")) | length == 1)?] | map([ .overview.title, .uuid ] | join(",")) | .[]'
+```
+
+##### Filtering by custom url
+
+```
+set -g @1password-items-jq-filter '.[] | [select(.overview.URLs | map(select(.u == "myspecial-url-filter")) | length == 1)?] | map([ .overview.title, .uuid ] | join(",")) | .[]'
+```
+
+Default: `''`
+
+Items come in the following format from which the filter operates:
+
+```
+[
+  {
+    "uuid": "some-long-uuid",
+    "overview": {
+      "URLs": [
+        { "u": "sudolikeaboss://local" }
+      ],
+      "title": "Some item",
+      "tags": ["tag_name"]
+    }
+  }
+]
+```
 
 ## Prior art
 

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -46,7 +46,16 @@ op_get_session() {
 }
 
 get_op_items() {
+  local cache_file="/tmp/tmux-op-items"
 
+  if [ -e $cache_file ]; then
+    echo "$(cat $cache_file)"
+  else
+    fetch_items
+  fi
+}
+
+fetch_items() {
   # The structure (we need) looks like the following:
   # [
   #   {
@@ -82,6 +91,25 @@ get_op_items() {
 
   op list items --vault="$OPT_VAULT" --session="$(op_get_session)" 2> /dev/null \
     | jq "$JQ_FILTER" --raw-output
+}
+
+cache_items() {
+  local items=$1
+  local cache_file="/tmp/tmux-op-items"
+
+  if ! [ -e $cache_file ]; then
+    echo "$items" > $cache_file
+  else
+    local last_update="$(stat -c %Y $cache_file)"
+    local now="$(date +%s)"
+    local seconds_since_last_update="$(($now-$last_update))"
+
+    # Remove cache file if last cache was from 6h ago
+    if [[ $seconds_since_last_update < 21600 ]]; then
+      display_message "ok"
+      rm $cache_file
+    fi
+  fi
 }
 
 get_op_item_password() {
@@ -153,6 +181,7 @@ main() {
     spinner_stop
   fi
 
+  cache_items "$items"
   selected_item_name="$(echo "$items" | awk -F ',' '{ print $1 }' | fzf --no-multi)"
 
   if [[ -n "$selected_item_name" ]]; then


### PR DESCRIPTION
## ☕ Purpose

After I started using #13, I've noticed that it takes too long if every time I fetch passwords my computer needs to go to the 1Password server to fetch them.

To fix this, I've created this PR, which saves a local cache containing the result of `op list-items`. The cache is available for 6 hours :)

This PR is based on #13, so some of the code here may looks different but it is actually the implementation of #13. As soon as that PR is merged, it would be more clear to see the diffs.

## 🧐 Checklist

- [x] Adds a function to save the cache
- [x] Adds a condition to use cache instead of fetch, if available
- [x] Adds a condition to remove the cache if it is older than  6hours