### PR TITLE
Remove `sudolikeaboss` compatibility and add a new option to allow filtering the items

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ sessions expires automatically after 30 minutes of inactivity.
 ### Configuring login items in 1Password
 
 In order to show only relevant login items and to maintain compatibility with
-[sudolikeaboss](https://github.com/ravenac95/sudolikeaboss), its required to set the value of the
-`website` field for each login item with the value of `sudolikeaboss://local`.
+[sudolikeaboss](https://github.com/ravenac95/sudolikeaboss), by default it is required to set the
+value of the `website` field for each login item with the value of `sudolikeaboss://local`. To
+override this behavior and provide customized filtering, see configuration options
+`@1password-enabled-url-filter` and `@1password-items-jq-filter` below.
 
 ## Configuration
 
@@ -120,6 +122,54 @@ set -g @1password-copy-to-clipboard 'on'
 ```
 
 Default: `'off'`
+
+#### Enabled URL Filter
+
+By default, the plugin maintains compatibility with [sudolikeaboss](https://github.com/ravenac95/sudolikeaboss) by
+filtering urls using the string "sudolikeaboss://local", by setting the following, the list of items will no longer be
+filtered.
+
+```
+set -g @1password-enabled-url-filter 'off'
+```
+
+Default: `'on'`
+
+#### Customize URL Filtering
+
+If complete customization of url filtering is required, a `jq` filter can be provided to filter and map
+items.
+
+##### Filtering by tags
+
+```
+set -g @1password-items-jq-filter '.[] | [select(.overview.tags | map(select(. == "tag_name")) | length == 1)?] | map([ .overview.title, .uuid ] | join(",")) | .[]'
+```
+
+##### Filtering by custom url
+
+```
+set -g @1password-items-jq-filter '.[] | [select(.overview.URLs | map(select(.u == "myspecial-url-filter")) | length == 1)?] | map([ .overview.title, .uuid ] | join(",")) | .[]'
+```
+
+Default: `''`
+
+Items come in the following format from which the filter operates:
+
+```
+[
+  {
+    "uuid": "some-long-uuid",
+    "overview": {
+      "URLs": [
+        { "u": "sudolikeaboss://local" }
+      ],
+      "title": "Some item",
+      "tags": ["tag_name"]
+    }
+  }
+]
+```
 
 ## Prior art
 

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Default: `'off'`
 
 #### Customize URL Filtering
 
-By default, all of th items will be shown. If complete customization of url filtering is required, a
-`jq` filter can be provided to filter and map items.
+By default, all of the items will be shown. If complete customization of url filtering is required,
+a `jq` filter can be provided to filter and map items.
 
 Items come in the following format from which the filter operates:
 
@@ -159,8 +159,8 @@ set -g @1password-items-jq-filter '
 ##### Filtering by custom url
 
 The following example will filter only the items that has a website field with the value of
-`sudolikeaboss://local`, similar to way [sudolikeaboss](https://github.com/ravenac95/sudolikeaboss)
-used to work.
+`sudolikeaboss://local`, similar to the way
+[sudolikeaboss](https://github.com/ravenac95/sudolikeaboss) used to work.
 
 ```sh
 set -g @1password-items-jq-filter ' \

--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ The following example will filter only the items that has a tag with a value of 
 
 ```sh
 set -g @1password-items-jq-filter '
-  .[]
-  | [select(.overview.tags | map(select(. == "some_tag")) | length == 1)?]
-  | map([ .overview.title, .uuid ]
-  | join(","))
-  | .[]
+  .[] \
+  | [select(.overview.tags | map(select(. == "some_tag")) | length == 1)?] \
+  | map([ .overview.title, .uuid ] \
+  | join(",")) \
+  | .[] \
 '
 ```
 
@@ -163,12 +163,12 @@ The following example will filter only the items that has a website field with t
 used to work.
 
 ```sh
-set -g @1password-items-jq-filter '
-  .[]
-  | [select(.overview.URLs | map(select(.u == "sudolikeaboss://local")) | length == 1)?]
-  | map([ .overview.title, .uuid ]
-  | join(","))
-  | .[]
+set -g @1password-items-jq-filter ' \
+  .[] \
+  | [select(.overview.URLs | map(select(.u == "sudolikeaboss://local")) | length == 1)?] \
+  | map([ .overview.title, .uuid ] \
+  | join(",")) \
+  | .[] \
 '
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,6 @@ and its password will automatically be filled.
 You may be required to perform a re-login (directly in the opened pane) since the 1Password CLI's
 sessions expires automatically after 30 minutes of inactivity.
 
-### Configuring login items in 1Password
-
-In order to show only relevant login items and to maintain compatibility with
-[sudolikeaboss](https://github.com/ravenac95/sudolikeaboss), by default it is required to set the
-value of the `website` field for each login item with the value of `sudolikeaboss://local`. To
-override this behavior and provide customized filtering, see configuration options
-`@1password-enabled-url-filter` and `@1password-items-jq-filter` below.
-
 ## Configuration
 
 Customize this plugin by setting these options in your `.tmux.conf` file. Make sure to reload the
@@ -123,40 +115,14 @@ set -g @1password-copy-to-clipboard 'on'
 
 Default: `'off'`
 
-#### Enabled URL Filter
-
-By default, the plugin maintains compatibility with [sudolikeaboss](https://github.com/ravenac95/sudolikeaboss) by
-filtering urls using the string "sudolikeaboss://local", by setting the following, the list of items will no longer be
-filtered.
-
-```
-set -g @1password-enabled-url-filter 'off'
-```
-
-Default: `'on'`
-
 #### Customize URL Filtering
 
-If complete customization of url filtering is required, a `jq` filter can be provided to filter and map
-items.
-
-##### Filtering by tags
-
-```
-set -g @1password-items-jq-filter '.[] | [select(.overview.tags | map(select(. == "tag_name")) | length == 1)?] | map([ .overview.title, .uuid ] | join(",")) | .[]'
-```
-
-##### Filtering by custom url
-
-```
-set -g @1password-items-jq-filter '.[] | [select(.overview.URLs | map(select(.u == "myspecial-url-filter")) | length == 1)?] | map([ .overview.title, .uuid ] | join(",")) | .[]'
-```
-
-Default: `''`
+By default, all of th items will be shown. If complete customization of url filtering is required, a
+`jq` filter can be provided to filter and map items.
 
 Items come in the following format from which the filter operates:
 
-```
+```json
 [
   {
     "uuid": "some-long-uuid",
@@ -165,10 +131,45 @@ Items come in the following format from which the filter operates:
         { "u": "sudolikeaboss://local" }
       ],
       "title": "Some item",
-      "tags": ["tag_name"]
+      "tags": ["some_tag"]
     }
   }
 ]
+```
+
+
+Default: `''`
+
+#### Examples
+
+##### Filtering by tags
+
+The following example will filter only the items that has a tag with a value of `some_tag`.
+
+```sh
+set -g @1password-items-jq-filter '
+  .[]
+  | [select(.overview.tags | map(select(. == "some_tag")) | length == 1)?]
+  | map([ .overview.title, .uuid ]
+  | join(","))
+  | .[]
+'
+```
+
+##### Filtering by custom url
+
+The following example will filter only the items that has a website field with the value of
+`sudolikeaboss://local`, similar to way [sudolikeaboss](https://github.com/ravenac95/sudolikeaboss)
+used to work.
+
+```sh
+set -g @1password-items-jq-filter '
+  .[]
+  | [select(.overview.URLs | map(select(.u == "sudolikeaboss://local")) | length == 1)?]
+  | map([ .overview.title, .uuid ]
+  | join(","))
+  | .[]
+'
 ```
 
 ## Prior art

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -15,7 +15,6 @@ declare -r TMP_TOKEN_FILE="$HOME/.op_tmux_token_tmp"
 declare -r OPT_SUBDOMAIN="$(get_tmux_option "@1password-subdomain" "my")"
 declare -r OPT_VAULT="$(get_tmux_option "@1password-vault" "")"
 declare -r OPT_COPY_TO_CLIPBOARD="$(get_tmux_option "@1password-copy-to-clipboard" "off")"
-declare -r OPT_ENABLED_URL_FILTER="$(get_tmux_option "@1password-enabled-url-filter" "on")"
 declare -r OPT_ITEMS_JQ_FILTER="$(get_tmux_option "@1password-items-jq-filter" "")"
 
 declare spinner_pid=""
@@ -55,23 +54,18 @@ get_op_items() {
   #       "URLs": [
   #         { "u": "sudolikeaboss://local" }
   #       ],
-  #       "title": "Some item"
+  #       "title": "Some item",
+  #       "tags": ["some_tag"]
   #     }
   #   }
   # ]
 
-  if [ -n "$OPT_ITEMS_JQ_FILTER" ]; then
-    local -r JQ_FILTER="$OPT_ITEMS_JQ_FILTER"
-  elif [ "$OPT_ENABLED_URL_FILTER" == "on" ]; then
-    local -r JQ_FILTER="
-      .[]
-      | [select(.overview.URLs | map(select(.u == \"sudolikeaboss://local\")) | length == 1)?]
-      | map([ .overview.title, .uuid ]
-      | join(\",\"))
-      | .[]
-    "
+  local JQ_FILTER
+
+  if [[ -n "$OPT_ITEMS_JQ_FILTER" ]]; then
+    JQ_FILTER="$OPT_ITEMS_JQ_FILTER"
   else
-    local -r JQ_FILTER="
+    JQ_FILTER="
       .[]
       | [select(.overview.URLs | map(select(.u)) | length == 1)?]
       | map([ .overview.title, .uuid ]


### PR DESCRIPTION
This PR continues from #13: it add the new `@1password-items-jq-filter` option that accepts a JQ filter, and removes the `sudolikeaboss` compatibility entirely.