### PR TITLE
Add the possibility to customize how to copy to clipboard.

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -14,6 +14,8 @@ declare -r TMP_TOKEN_FILE="$HOME/.op_tmux_token_tmp"
 
 declare -r OPT_SUBDOMAIN="$(get_tmux_option "@1password-subdomain" "my")"
 declare -r OPT_VAULT="$(get_tmux_option "@1password-vault" "")"
+declare -r OPT_CLIPBOARD_CMD="$(get_tmux_option "@1password-clipboard-cmd" "xclip")"
+declare -r OPT_CLIPBOARD_OPTS="$(get_tmux_option "@1password-clipboard-opts" "-i")"
 declare -r OPT_COPY_TO_CLIPBOARD="$(get_tmux_option "@1password-copy-to-clipboard" "off")"
 declare -r OPT_ITEMS_JQ_FILTER="$(get_tmux_option "@1password-items-jq-filter" "")"
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -26,8 +26,8 @@ is_cmd_exists() {
 copy_to_clipboard() {
   if [[ "$(uname)" == "Darwin" ]] && is_cmd_exists "pbcopy"; then
     echo -n "$1" | pbcopy
-  elif [[ "$(uname)" == "Linux" ]] && is_cmd_exists "xclip"; then
-    echo -n "$1" | xclip -i
+  elif [[ "$(uname)" == "Linux" ]] && is_cmd_exists "$OPT_CLIPBOARD_CMD"; then
+    echo -n "$1" | "$OPT_CLIPBOARD_CMD" "$OPT_CLIPBOARD_OPTS"
   else
     return 1
   fi
@@ -38,8 +38,8 @@ clear_clipboard() {
 
   if [[ "$(uname)" == "Darwin" ]] && is_cmd_exists "pbcopy"; then
     tmux run-shell -b "sleep $SEC && echo '' | pbcopy"
-  elif [[ "$(uname)" == "Linux" ]] && is_cmd_exists "xclip"; then
-    tmux run-shell -b "sleep $SEC && echo '' | xclip -i"
+  elif [[ "$(uname)" == "Linux" ]] && is_cmd_exists "$OPT_CLIPBOARD_CMD"; then
+    tmux run-shell -b "sleep $SEC && echo '' | $OPT_CLIPBOARD_CMD $OPT_CLIPBOARD_OPTS"
   else
     return 1
   fi


### PR DESCRIPTION
The idea behind this PR is to add customisation on the clipboard. For example, I use `xsel` instead but if you are on LInux working on wayland, xclip might not work or you could be running another clipboard manager whatsoever. This solves the issue by adding two configuration keys.