### PR TITLE
List (most of) the items regarding of having a website

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,15 @@ Default: `'off'`
 By default, all of the items will be shown. If complete customization of url filtering is required,
 a `jq` filter can be provided to filter and map items.
 
-Items come in the following format from which the filter operates:
+Items comes from the [`op list items`
+command](https://support.1password.com/command-line/#list-objects) in the following format, from
+which the filter operates:
 
 ```json
 [
   {
     "uuid": "some-long-uuid",
+    "templateUuid": "001",
     "overview": {
       "URLs": [
         { "u": "sudolikeaboss://local" }

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -47,9 +47,11 @@ op_get_session() {
 get_op_items() {
 
   # The structure (we need) looks like the following:
+  #
   # [
   #   {
   #     "uuid": "some-long-uuid",
+  #     "templateUuid": "001",
   #     "overview": {
   #       "URLs": [
   #         { "u": "sudolikeaboss://local" }
@@ -59,6 +61,10 @@ get_op_items() {
   #     }
   #   }
   # ]
+  #
+  # Where `templateUuid` is:
+  #   - `"001"` for a login item
+  #   - `"005"` for a password item
 
   local JQ_FILTER
 
@@ -67,7 +73,12 @@ get_op_items() {
   else
     JQ_FILTER="
       .[]
-      | [select(.overview.URLs | map(select(.u)) | length == 1)?]
+      | [
+          select(
+            (.templateUuid == \"001\" and (.overview.URLs | map(select(.u)) | length >= 1)) or
+            (.templateUuid == \"005\")
+          )?
+        ]
       | map([ .overview.title, .uuid ]
       | join(\",\"))
       | .[]


### PR DESCRIPTION
This PR updates the default JQ filter so more items will be shown. The previous JQ filter selected only the items that had **exactly 1 website associated**.

As mentioned in #24, this excluded login items and password that had more than 1 website or not any at all.

The new behaviour will act as follows:

- A **login item** will show up if it have at least 1 website associated;
- A **password items** will show up regardless of whether there is a website associated to it.

Resolves #24.