### PR TITLE
Added the @1password-debug option to help with debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ set -g @1password-items-jq-filter ' \
 '
 ```
 
+#### Debug mode
+
+If you're having any trouble with the plugin and would like to debug it's output in a more
+convenient way, this option will prevent the pane to be closed.
+
+```
+set -g @1password-debug 'on'
+```
+
 ## Prior art
 
 Also see:

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -16,18 +16,28 @@ declare -r OPT_SUBDOMAIN="$(get_tmux_option "@1password-subdomain" "my")"
 declare -r OPT_VAULT="$(get_tmux_option "@1password-vault" "")"
 declare -r OPT_COPY_TO_CLIPBOARD="$(get_tmux_option "@1password-copy-to-clipboard" "off")"
 declare -r OPT_ITEMS_JQ_FILTER="$(get_tmux_option "@1password-items-jq-filter" "")"
+declare -r OPT_DEBUG="$(get_tmux_option "@1password-debug" "off")"
 
 declare spinner_pid=""
 
 # ------------------------------------------------------------------------------
 
 spinner_start() {
+  if [[ "$OPT_DEBUG" == "on" ]]; then
+    echo "... $1"
+    return
+  fi
+
   tput civis
   show_spinner "$1" &
   spinner_pid=$!
 }
 
 spinner_stop() {
+  if [[ "$OPT_DEBUG" == "on" ]]; then
+    return
+  fi
+
   tput cnorm
   kill "$spinner_pid" &> /dev/null
   spinner_pid=""
@@ -207,6 +217,11 @@ main() {
 
       # Use `send-keys`
       tmux send-keys -t "$ACTIVE_PANE" "$selected_item_password"
+    fi
+
+    if [[ "$OPT_DEBUG" == "on" ]]; then
+      echo "tmux-1password: @1password-debug is on. Press [ENTER] to continue."
+      read -r
     fi
   fi
 }


### PR DESCRIPTION
This PR adds a simple debug mode that prevents the pane to be closed at the end of the run. It helps with #5, but does not resolves it as I would eventually want to have a more robust debug mode.