### PR TITLE
Ensure  semver gets parsed correctly

### DIFF
--- a/scripts/utils/semver.sh
+++ b/scripts/utils/semver.sh
@@ -12,10 +12,12 @@ semver::compare() {
         return 0
     fi
 
-    local IFS="."
     local i
-    local version_1="$1"
-    local version_2="$2"
+    local version_1
+    local version_2
+
+    IFS='.' read -r -a version_1 <<< "$1"
+    IFS='.' read -r -a version_2 <<< "$2"
 
     # Fill empty fields in version_1 with zeros
     for ((i=${#version_1[@]}; i<${#version_2[@]}; i++)); do


### PR DESCRIPTION
I'm getting some errors from the semver parser when running
```
./utils/semver.sh: line 31: ((: 10#2.0.2 > 10#2.0.0: syntax error: invalid arithmetic operator (error token is ".0.2 > 10#2.0.0")
./utils/semver.sh: line 35: ((: 10#2.0.2 < 10#2.0.0: syntax error: invalid arithmetic operator (error token is ".0.2 < 10#2.0.0")
```

From a little debugging it seems the versions aren't getting split by the `IFS` value and the length of both values is 1. Looking at the original source it seems the parentheses are important to get the values to split.

```bash
local i ver1=($1) ver2=($2)
```

However, according to the shellcheck language server the safer way to parse the values is to use `read`
https://github.com/koalaman/shellcheck/wiki/SC2206

Happy to swap back to the original implementation if you prefer though as both seem to work!