### PR TITLE
temporalilly disable synchronize panes to type in fzf only

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -25,6 +25,7 @@ main() {
   local selected_item_name
   local selected_item_uuid
   local selected_item_password
+  local synchronize_panes_reset_value
 
   local -ra fzf_opts=(
     --no-multi
@@ -48,7 +49,11 @@ main() {
   items="$(op::get_all_items)"
   spinner::stop
 
+  synchronize_panes_reset_value=$(tmux::disable_synchronize_panes)
+
   selected_item="$(echo "$items" | awk -F ',' '{ print $1 }' | fzf "${fzf_opts[@]}")"
+
+  tmux::set_synchronize_panes "${synchronize_panes_reset_value}"
 
   if [[ -n "$selected_item" ]]; then
     selected_item_name=${selected_item#*,}

--- a/scripts/utils/tmux.sh
+++ b/scripts/utils/tmux.sh
@@ -17,3 +17,16 @@ tmux::get_option() {
 tmux::display_message() {
   tmux display-message "tmux-1password: $1"
 }
+
+tmux::disable_synchronize_panes() {
+  if [ "$(tmux show-options -wv synchronize-panes)" == "on" ]; then
+    tmux::set_synchronize_panes "off"
+    echo "on"
+  else
+    echo "off"
+  fi
+}
+
+tmux::set_synchronize_panes() {
+  tmux set-window-option synchronize-panes "${1}"
+}


### PR DESCRIPTION
when using multiple panes in a window, and the `synchronize-panes` option, typing into the fzf menu will write into the other panes too. temporarily disable `synchronize-panes` before showing fzf and re-enable it afterwards.