### PR TITLE
Fix fetching passwords and TOTPs from vault

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -47,7 +47,7 @@ main() {
   items="$(op::get_all_items)"
   spinner::stop
 
-  readarray -t selection <<< "$(echo "$items" | awk -F ',' '{ print $1 }' | fzf "${fzf_opts[@]}")"
+  IFS=$'\n' read -r -d '' -a selection < <(echo "$items" | awk -F ',' '{ print $1 }' | fzf "${fzf_opts[@]}")
   key_pressed="${selection[0]}"
   selected_item="${selection[1]}"
 

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -28,9 +28,8 @@ main() {
 
   local -ra fzf_opts=(
     --no-multi
-    "--header=enter=password, ctrl-u=totp"
-    --bind "enter:execute(echo pass,{+})+abort"
-    --bind "ctrl-u:execute(echo totp,{+})+abort"
+    --header="enter=password, ctrl-u=totp"
+    --expect=enter,ctrl-u
   )
 
   # Check for version
@@ -48,27 +47,29 @@ main() {
   items="$(op::get_all_items)"
   spinner::stop
 
-  selected_item="$(echo "$items" | awk -F ',' '{ print $1 }' | fzf "${fzf_opts[@]}")"
+  readarray -t selection <<< "$(echo "$items" | awk -F ',' '{ print $1 }' | fzf "${fzf_opts[@]}")"
+  key_pressed="${selection[0]}"
+  selected_item="${selection[1]}"
 
-  if [[ -n "$selected_item" ]]; then
+  if [[ -n "${selected_item}" ]]; then
     selected_item_name=${selected_item#*,}
     selected_item_uuid="$(echo "$items" | grep "^$selected_item_name," | awk -F ',' '{ print $2 }')"
 
-    case ${selected_item%%,*} in
-      pass)
+    case ${key_pressed} in
+      enter)
         spinner::start "Fetching password"
         selected_item_password="$(op::get_item_password "$selected_item_uuid")"
         spinner::stop
         ;;
 
-      totp)
+      ctrl-u)
         spinner::start "Fetching totp"
         selected_item_password="$(op::get_item_totp "$selected_item_uuid")"
         spinner::stop
         ;;
 
       *)
-        tmux::display_message "Unknown item request"
+        tmux::display_message "Unknown key pressed"
         ;;
     esac
 


### PR DESCRIPTION
Recently I've been having issues with autotype and copy to clipboard using the plugin. I found that in some shells using the `echo pass,<entry>` and `echo totp,<entry>` `--bind` commands in a subshell did not populate the script variables correctly. I've opted for using the `--expect` flag to `fzf`, which always prints the key pressed to select the entry along the entry itself. Then, using `readarray` this is split into the correct variables again.